### PR TITLE
Column name comparison mode property

### DIFF
--- a/GenericParsing.UnitTests/UnitTests.cs
+++ b/GenericParsing.UnitTests/UnitTests.cs
@@ -676,7 +676,7 @@ namespace GenericParsing.UnitTests
 
                     // Checking using integers to index the columns.
                     Assert.AreEqual(null, parser["foobar"]);
-                    Assert.AreEqual("1", parser["a"]);                   
+                    Assert.AreEqual("1", parser["a"]);
                 }
 
                 // Check this without a header.

--- a/GenericParsing.UnitTests/UnitTests.cs
+++ b/GenericParsing.UnitTests/UnitTests.cs
@@ -676,7 +676,7 @@ namespace GenericParsing.UnitTests
 
                     // Checking using integers to index the columns.
                     Assert.AreEqual(null, parser["foobar"]);
-                    Assert.AreEqual("1", parser["a"]);
+                    Assert.AreEqual("1", parser["a"]);                   
                 }
 
                 // Check this without a header.
@@ -695,6 +695,46 @@ namespace GenericParsing.UnitTests
                     // Checking using integers to index the columns.
                     Assert.AreEqual(null, parser["foobar"]);
                     Assert.AreEqual(null, parser["a"]);
+                }
+            }
+
+            [TestMethod]
+            public void BoundsCheckOnDataWithColumnNameComparisonMode()
+            {
+                using (GenericParserAdapter parser = new GenericParserAdapter())
+                {
+                    UnitTests._PrepParserForTest(parser, "ReadingInHeader");
+                    parser.ColumnNameComparisonMode = null;
+
+                    Assert.IsTrue(parser.Read());
+                    Assert.AreEqual("1", parser["a"]);
+                    Assert.AreEqual(null, parser["A"]);
+                    Assert.AreEqual("6", parser["f"]);
+                    Assert.AreEqual(null, parser["F"]);
+                }
+
+                using (GenericParserAdapter parser = new GenericParserAdapter())
+                {
+                    UnitTests._PrepParserForTest(parser, "ReadingInHeader");
+                    parser.ColumnNameComparisonMode = StringComparison.InvariantCulture;
+
+                    Assert.IsTrue(parser.Read());
+                    Assert.AreEqual("1", parser["a"]);
+                    Assert.AreEqual(null, parser["A"]);
+                    Assert.AreEqual("6", parser["f"]);
+                    Assert.AreEqual(null, parser["F"]);
+                }
+
+                using (GenericParserAdapter parser = new GenericParserAdapter())
+                {
+                    UnitTests._PrepParserForTest(parser, "ReadingInHeader");
+                    parser.ColumnNameComparisonMode = StringComparison.InvariantCultureIgnoreCase;
+
+                    Assert.IsTrue(parser.Read());
+                    Assert.AreEqual("1", parser["a"]);
+                    Assert.AreEqual("1", parser["A"]);
+                    Assert.AreEqual("6", parser["f"]);
+                    Assert.AreEqual("6", parser["F"]);
                 }
             }
 

--- a/GenericParsing/GenericParser.cs
+++ b/GenericParsing/GenericParser.cs
@@ -483,6 +483,33 @@ namespace GenericParsing
                 }
             }
         }
+
+        /// <summary>
+        /// Gets or sets the string comparison mode when retrieving data by column name.
+        /// <remarks>
+        ///   <para>
+        ///     Default: <see langword="null"/>
+        ///   </para>
+        ///   <para>
+        ///     If parsing has started, this value cannot be updated.
+        ///   </para>
+        /// </remarks>
+        /// </summary>
+        public StringComparison? ColumnNameComparisonMode
+        {
+            get
+            {
+                return this.m_enColumnNameComparisonMode;
+            }
+            set
+            {
+                if (this.m_ParserState == ParserState.Parsing)
+                    throw new InvalidOperationException("Parsing has already begun, close the existing parse first.");
+
+                this.m_enColumnNameComparisonMode = value;
+            }
+        }
+
         /// <summary>
         ///   Gets or sets whether or not the first row of data in the file contains
         ///   the header information.
@@ -1830,6 +1857,7 @@ namespace GenericParsing
         private int m_intMaxBufferSize;
         private int m_intMaxRows;
         private int m_intSkipStartingDataRows;
+        private StringComparison? m_enColumnNameComparisonMode;
         private int m_intExpectedColumnCount;
         private bool m_blnFirstRowHasHeader;
         private bool m_blnTrimResults;
@@ -2367,7 +2395,14 @@ namespace GenericParsing
         private int _GetColumnIndex(string strColumnName)
         {
             if (this.m_blnHeaderRowFound && (strColumnName != null))
+            { 
+                if (m_enColumnNameComparisonMode.HasValue)
+                {
+                    return this.m_lstColumnNames.FindIndex(c => c.Equals(strColumnName, m_enColumnNameComparisonMode.Value)); 
+                }
+
                 return this.m_lstColumnNames.IndexOf(strColumnName);
+            }
             else
                 return -1;
         }

--- a/GenericParsing/GenericParser.cs
+++ b/GenericParsing/GenericParser.cs
@@ -907,7 +907,7 @@ namespace GenericParsing
         ///   Gets the data found in the current row of data by the column index.
         /// </summary>
         /// <value>The value of the column at the given index.</value>
-        /// <param name="intColumnIndex">The index of the column to retreive.</param>
+        /// <param name="intColumnIndex">The index of the column to retrieve.</param>
         /// <remarks>
         ///   If the column is outside the bounds of the columns found or the column
         ///   does not possess a name, it will return <see langword="null"/>.
@@ -926,7 +926,7 @@ namespace GenericParsing
         ///   Gets the data found in the current row of data by the column name.
         /// </summary>
         /// <value>The value of the column with the given column name.</value>
-        /// <param name="strColumnName">The name of the column to retreive.</param>
+        /// <param name="strColumnName">The name of the column to retrieve.</param>
         /// <remarks>
         ///   If the header has yet to be parsed (or no header exists), the property will
         ///   return <see langword="null"/>.


### PR DESCRIPTION
Adding new feature: column name comparison mode, using the [System.StringComparison](https://learn.microsoft.com/en-us/dotnet/api/system.stringcomparison) enum, to allow retrieving data by column name according to the desired setting (i.e.: InvariantCultureIgnoreCase).

Refers to https://github.com/AndrewRissing/GenericParsing/issues/22 
