### PR TITLE
add method to get column names / add some unit tests

### DIFF
--- a/GenericParsing.UnitTests/UnitTests.cs
+++ b/GenericParsing.UnitTests/UnitTests.cs
@@ -651,6 +651,11 @@ namespace GenericParsing.UnitTests
                     // Checking using integers to index the columns.
                     Assert.Equal(0, parser.GetColumnIndex("a"));
                     Assert.Equal(-1, parser.GetColumnIndex("foobar"));
+
+                    //Checking header columns
+                    Assert.NotNull(parser.GetColumnNames());
+                    Assert.Equal(6, parser.GetColumnNames().Count);
+                    Assert.Equal("a,b,c,d,e,f", String.Join(",", parser.GetColumnNames()));
                 }
 
                 // Check this without a header.
@@ -669,6 +674,9 @@ namespace GenericParsing.UnitTests
                     // Checking using integers to index the columns.
                     Assert.Equal(-1, parser.GetColumnIndex("a"));
                     Assert.Equal(-1, parser.GetColumnIndex("foobar"));
+
+                    // Checking if header columns is null                    
+                    Assert.Null(parser.GetColumnNames());
                 }
             }
 
@@ -1072,6 +1080,11 @@ namespace GenericParsing.UnitTests
                                     Assert.Equal("Column4", parser.GetColumnName(3));
                                     Assert.Equal("Column5", parser.GetColumnName(4));
                                     Assert.Equal("Column6", parser.GetColumnName(5));
+
+                                    //checking the header columns
+                                    Assert.NotNull(parser.GetColumnNames());
+                                    Assert.Equal(6, parser.GetColumnNames().Count);
+                                    Assert.Equal("Column1,Column2,Column3,Column4,Column5,Column6", String.Join(",", parser.GetColumnNames()));
 
                                     intCurrentDataRowIndex = (parser.DataRowNumber - 1) % NUMBER_OF_ROWS_IN_BASE_DATA;
 

--- a/GenericParsing/GenericParser.cs
+++ b/GenericParsing/GenericParser.cs
@@ -1804,6 +1804,26 @@ namespace GenericParsing
         /// </summary>
         public event EventHandler Disposed;
 
+        /// <summary>
+        ///   Returns a clone of the current column names, if available.
+        /// </summary>
+        /// <remarks>
+        ///   The property <c>FirstRowHasHeader</c> must be set to <c>true</c>
+        ///   for column names to be available.
+        /// </remarks>
+        /// <returns>
+        ///   A new <see cref="List{String}"/> containing the column names,
+        ///   or <see langword="null"/> if no column names are defined.
+        /// </returns>
+        public List<string> GetColumnNames()
+        {
+            if (this.m_lstColumnNames != null && this.m_blnFirstRowHasHeader &&this.m_lstColumnNames.Count > 0)
+            {
+                return new List<string>(this.m_lstColumnNames);
+            }
+            return null;
+        }
+
         #endregion Public Code
 
         #region Protected Code


### PR DESCRIPTION
This pull request adds a method to retrieve column names as a list, addressing the feature request described in issue #26. 

Summary of changes:
- Implemented a method `GetColumnNames()` (name can be adjusted as needed) that returns the list of column names.
- Added unit tests to verify the correct behavior of this method.